### PR TITLE
bump to v1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## Changelog
+
+### 0.1.2
+
+ - the `TDigest` was not handling ints very well. For example, given `[1,2,2,2,2,2,3]`, it would return that the percentile was `3`. With the fix, it is possible that a centroid can exceed its size threshold.
+ - `batch_update` function now has a kwarg to specify the weight of all elements in the inputted array.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 
 setup(name='tdigest',
-      version='0.1.1',
+      version='0.1.2',
       description='T-Digest data structure',
       author='Cam Davidson-pilon',
       author_email='cam.davidson.pilon@gmail.com',


### PR DESCRIPTION
### 0.1.2

 - the `TDigest` was not handling ints very well. For example, given `[1,2,2,2,2,2,3]`, it would return that the percentile was `3`. With the fix, it is possible that a centroid can exceed its size threshold.
 - `batch_update` function now has a kwarg to specify the weight of all elements in the inputted array.