### PR TITLE
V0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 0.3.0
+ - The definition of percentile was used incorrectly in tdigest. Previous to 0.3.0, 
+  a percentile was defined between 0 and 1. In fact, a percentile is defined between 0 and 100 (hence the 'percent' in percentile). This follows other conventions, like in Numpy and Scipy. This affects the `TDigest.percentile` function. 
+
 ### 0.2.0
  - Make the *tdigest* library Python3 compatible. 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ digest = TDigest()
 for x in range(5000):
     digest.update(random())
 
-print digest.percentile(0.15) # about 0.15, as 0.15 is the 15th percentile of the Uniform(0,1) distribution
+print digest.percentile(15) # about 0.15, as 0.15 is the 15th percentile of the Uniform(0,1) distribution
 ```
 
 #### Update the digest in batches
@@ -36,14 +36,14 @@ print digest.percentile(0.15) # about 0.15, as 0.15 is the 15th percentile of th
 ```
 another_digest = TDigest()
 another_digest.batch_update(random(5000))
-print another_digest.percentile(0.15)
+print another_digest.percentile(15)
 ```
 
 #### Sum two digests to create a new digest
 
 ```
 sum_digest = digest + another_digest 
-sum_digest.percentile(0.3) # about 0.3
+sum_digest.percentile(30) # about 0.3
 ```
 
 ### API 
@@ -53,9 +53,9 @@ sum_digest.percentile(0.3) # about 0.3
  - `update(x, w=1)`: update the tdigest with value `x` and weight `w`.
  - `batch_update(x, w=1)`: update the tdigest with values in array `x` and weight `w`.
  - `compress()`: perform a compression on the underlying data structure that will shrink the memory footprint of it, without hurting accuracy. Good to perform after adding many values. 
- - `percentile(q)`: return the `q`th percentile. Example: `q=.50` is the median.
- - `quantile(q)`: return the percentile the value `q` is at. 
- - `trimmed_mean(q1, q2)`: return the mean of data set without the values below and above the `q1` and `q2` percentile respectively. 
+ - `percentile(p)`: return the `p`th percentile. Example: `p=50` is the median.
+ - `quantile(q)`: return the CDF the value `q` is at. 
+ - `trimmed_mean(p1, p2)`: return the mean of data set without the values below and above the `p1` and `p2` percentile respectively. 
 
  
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 
 setup(name='tdigest',
-      version='0.2.0',
+      version='0.3.0',
       description='T-Digest data structure',
       author='Cam Davidson-pilon',
       author_email='cam.davidson.pilon@gmail.com',

--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -143,29 +143,29 @@ class TDigest(object):
             T.update(c_i.mean, c_i.count)
         self.C = T.C
 
-    def percentile(self, q):
+    def percentile(self, p):
         """ 
-        Computes the percentile of a specific value in [0,1], ie. computes F^{-1}(q) where F^{-1} denotes
-        the inverse CDF of the distribution. 
+        Computes the percentile of a specific value in [0,100].
 
         """
-        if not (0 <= q <= 1):
-            raise ValueError("q must be between 0 and 1, inclusive.")
+        if not (0 <= p <= 100):
+            raise ValueError("p must be between 0 and 100, inclusive.")
 
         t = 0
-        q *= self.n
+        p = float(p)/100.
+        p *= self.n
 
         for i, key in enumerate(self.C.keys()):
             c_i = self.C[key]
             k = c_i.count
-            if q < t + k:
+            if p < t + k:
                 if i == 0:
                     return c_i.mean
                 elif i == len(self) - 1:
                     return c_i.mean
                 else:
                     delta = (self.C.succ_item(key)[1].mean - self.C.prev_item(key)[1].mean) / 2.
-                return c_i.mean + ((q - t) / k - 0.5) * delta
+                return c_i.mean + ((p - t) / k - 0.5) * delta
 
             t += k
         return self.C.max_item()[1].mean
@@ -193,33 +193,35 @@ class TDigest(object):
             t += c_i.count
         return 1
 
-    def trimmed_mean(self, q1, q2):
+    def trimmed_mean(self, p1, p2):
         """
-        Computes the mean of the distribution between the two percentiles q1 and q2.
+        Computes the mean of the distribution between the two percentiles p1 and p2.
         This is a modified algorithm than the one presented in the original t-Digest paper. 
 
         """
-        if not (q1 < q2):
-            raise ValueError("q must be between 0 and 1, inclusive.")
+        if not (p1 < p2):
+            raise ValueError("p1 must be between 0 and 100 and less than p2.")
 
         s = k = t = 0
-        q1 *= self.n
-        q2 *= self.n
+        p1 /= 100.
+        p2 /= 100.
+        p1 *= self.n
+        p2 *= self.n
         for i, key in enumerate(self.C.keys()):
             c_i = self.C[key]
             k_i = c_i.count
-            if q1 < t + k_i:
+            if p1 < t + k_i:
                 if i == 0:
                     delta = self.C.succ_item(key)[1].mean - c_i.mean
                 elif i == len(self) - 1:
                     delta = c_i.mean - self.C.prev_item(key)[1].mean
                 else:
                     delta = (self.C.succ_item(key)[1].mean - self.C.prev_item(key)[1].mean) / 2.
-                nu = ((q1 - t) / k_i - 0.5) * delta
+                nu = ((p1 - t) / k_i - 0.5) * delta
                 s += nu * k_i * c_i.mean
                 k += nu * k_i
 
-            if q2 < t + k_i:
+            if p2 < t + k_i:
                 return s/k
             t += k_i
 
@@ -235,11 +237,11 @@ if __name__ == '__main__':
     x = random.random(size=10000)
     T1.batch_update(x)
 
-    print(abs(T1.percentile(.5) - 0.5))
-    print(abs(T1.percentile(.1) - .1))
-    print(abs(T1.percentile(.9) - 0.9))
-    print(abs(T1.percentile(.01) - 0.01))
-    print(abs(T1.percentile(.001) - 0.001))
+    print(abs(T1.percentile(50) - 0.5))
+    print(abs(T1.percentile(10) - .1))
+    print(abs(T1.percentile(90) - 0.9))
+    print(abs(T1.percentile(1) - 0.01))
+    print(abs(T1.percentile(0.1) - 0.001))
     print(T1.trimmed_mean(0.5, 1.))
 
 

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -121,7 +121,7 @@ class TestTDigest():
         data = random.randn(100000)
         t.batch_update(data)
         assert t.percentile(0) == data.min()
-        assert t.percentile(1.) == data.max()
+        assert t.percentile(100.) == data.max()
 
     def test_adding_centroid_with_exisiting_key_does_not_break_synchronicity(self, empty_tdigest, example_centroids):
         td = empty_tdigest
@@ -138,23 +138,23 @@ class TestStatisticalTests():
         x = random.random(size=10000)
         t.batch_update(x)
 
-        assert abs(t.percentile(.5) - 0.5) < 0.02
-        assert abs(t.percentile(.1) - .1) < 0.01
-        assert abs(t.percentile(.9) - 0.9) < 0.01
-        assert abs(t.percentile(.01) - 0.01) < 0.005
-        assert abs(t.percentile(.99) - 0.99) < 0.005
-        assert abs(t.percentile(.001) - 0.001) < 0.001
-        assert abs(t.percentile(.999) - 0.999) < 0.001
+        assert abs(t.percentile(50) - 0.5) < 0.02
+        assert abs(t.percentile(10) - .1) < 0.01
+        assert abs(t.percentile(90) - 0.9) < 0.01
+        assert abs(t.percentile(1) - 0.01) < 0.005
+        assert abs(t.percentile(99) - 0.99) < 0.005
+        assert abs(t.percentile(0.1) - 0.001) < 0.001
+        assert abs(t.percentile(99.9) - 0.999) < 0.001
         
     def test_ints(self):
         t = TDigest()
         t.batch_update([1,2,3])
-        assert t.percentile(0.5) == 2
+        assert t.percentile(50) == 2
 
         t = TDigest()
         x = [1,2,2,2,2,2,2,2,3]
         t.batch_update(x)
-        assert t.percentile(0.5) == 2
+        assert t.percentile(50) == 2
         assert sum([c.count for c in t.C.values()]) == len(x)
 
 class TestCentroid():


### PR DESCRIPTION
### 0.3.0
 - The definition of percentile was used incorrectly in tdigest. Previous to 0.3.0, 
  a percentile was defined between 0 and 1. In fact, a percentile is defined between 0 and 100 (hence the 'percent' in percentile). This follows other conventions, like in Numpy and Scipy. This affects the `TDigest.percentile` function. 