### PR TITLE
Replaced random.shuffle with pyudorandom

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bintrees
+pyudorandom

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(name='tdigest',
       long_description=read('README.md'),
       install_requires=[
           "bintrees",
+          "pyudorandom"
       ],
       classifiers=[
         "Development Status :: 4 - Beta",

--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 
-from random import shuffle, choice
+from random import choice
 from bintrees import FastRBTree as RBTree
 import pyudorandom
 from itertools import chain
@@ -136,8 +136,7 @@ class TDigest(object):
     def compress(self):
         T = TDigest(self.delta, self.K)
         C = list(self.C.values())
-        shuffle(C)
-        for c_i in C:
+        for c_i in pyudorandom.items(C):
             T.update(c_i.mean, c_i.count)
         self.C = T.C
 

--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 
 from random import shuffle, choice
 from bintrees import FastRBTree as RBTree
+import pyudorandom
+from itertools import chain
 
 class Centroid(object):
 
@@ -30,13 +32,9 @@ class TDigest(object):
         self.K = K
 
     def __add__(self, other_digest):
-        C1 = list(self.C.values())
-        C2 = list(other_digest.C.values())
-        shuffle(C1)
-        shuffle(C2)
-        data = C1 + C2
+        data = list(chain(self.C.values(), other_digest.C.values()))
         new_digest = TDigest(self.delta, self.K)
-        for c in data:
+        for c in pyudorandom.items(data):
             new_digest.update(c.mean, c.count)
 
         return new_digest


### PR DESCRIPTION
Hi @CamDavidsonPilon, 

I have been meaning to do this PR for a while now, but instead of including lots of utility code in your repo, I placed it in https://github.com/mewwts/pyudorandom. 

For larger lists, `random.shuffle` can be very slow, and simple tests show that pyudorandom can be up to twice as fast. 

I understand that introducing dependencies is something you would rather not, but I think this can be a meaningful change.

Keep in mind that this change will not guarantee randomness, but rather will pick elements non-successively from the list. I think that is what is needed here.

If there's any modifications to this PR you would like to have made, please do not hesitate.