### PR TITLE
Add some infrastructure for an easy clean local build/test loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pyc
+/env
+/.cache
+/*.egg-info

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,71 @@
+
+PROJ=tdigest
+PYTHON=python
+TEST_TIMEOUT=600
+
+
+default:
+	@echo "Try one of:"
+	@echo "    env - build a dev env in env/"
+	@echo "    test - run all the tests"
+	@echo "    test1 - run tests until one fails"
+	@echo "    package - build a .whl for potential deployment"
+	@echo "    release - build the .whl on the current machine with a new version number, tag and push the source"
+	@echo "    deploy - (requires sudo) build and install the .whl on the current machine"
+	@echo "    clean - nuke all generated output"
+
+env:
+	virtualenv --python=`which $(PYTHON)` env
+	@if [ -d vendor ]; then \
+    	    ./env/bin/pip install -e .[tests] --find-links vendor/ ;\
+	else \
+    	    ./env/bin/pip install -e .[tests] ;\
+	fi
+
+test: env
+	./env/bin/py.test tests --timeout=$(TEST_TIMEOUT)
+
+test1: env
+	./env/bin/py.test -x --ff tests --timeout=$(TEST_TIMEOUT)
+
+shippabletest: env
+	mkdir -p shippable/testresults shippable/codecoverage
+	./env/bin/py.test \
+	     --cov-report xml \
+	     --cov=$(PROJ) \
+	     --junitxml=shippable/testresults/pytest.xml tests
+	mv coverage.xml shippable/codecoverage/
+
+travistest: env
+	./env/bin/py.test -v \
+	     --cov-report xml \
+	     --cov-report term \
+	     --cov-report html \
+	     --cov=$(PROJ) \
+	     --junitxml=testresults.xml tests
+
+clean:
+	rm -rf env build dist *.egg *.egg-info 
+
+package:
+	$(PYTHON) setup.py bdist_wheel
+
+deploy: package
+	sudo pip install --upgrade `ls ./dist/*.whl | tail -1`
+
+release:
+	@if git tag | grep -q v`$(PYTHON) setup.py -V` ; then\
+		echo "Already released this version.";\
+		echo "Update the version number and try again.";\
+		exit 1;\
+	fi
+	@if [ `git status --short | wc -l` != 0 ]; then\
+		echo "Uncommited code. Aborting." ;\
+		exit 1;\
+	fi
+	$(PYTHON) setup.py bdist_wheel
+	git tag v`$(PYTHON) setup.py -V`
+	git push
+	git push --tags
+
+.PHONY: default package deploy release clean 

--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,5 @@ setup(name='tdigest',
             "../MANIFEST",
         ]
       },
+      extras_require = { 'tests': [ 'pytest', 'pytest-timeout', 'pytest-cov', 'numpy' ] },
 )


### PR DESCRIPTION
This includes:

   *  A (non-comprehensive) python-ish .gitignore
   * A tests 'extras' subpackage to designate what packages need to be installed to run tests.  Used by:
   * A Makefile that will:
      * build a local virtualenv to run tests in (for easy, clean, reproducible testing)
      * run tests in the built virtualenv in both stop-on-first-fail and run-all modes (test1 vs test targets respectively)
      * Automate the building of wheels and even build and tag releases if you wish

None of this is strictly necessary, but it's a way to run tests without having to do global installs of dependencies.  There's also prebuilt test targets that know about putting things in the right places for shippable.com and travis-ci.org, so the commands those things run become single calls to make.
