### PR TITLE
Do not compress empty tdigests

### DIFF
--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -138,8 +138,9 @@ class TDigest(object):
     def compress(self):
         T = TDigest(self.delta, self.K)
         C = list(self.C.values())
-        for c_i in pyudorandom.items(C):
-            T.update(c_i.mean, c_i.count)
+        if len(C) > 0:
+            for c_i in pyudorandom.items(C):
+                T.update(c_i.mean, c_i.count)
         self.C = T.C
 
     def percentile(self, p):

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -130,6 +130,10 @@ class TestTDigest():
         td._add_centroid(Centroid(-1.1, 10))
         assert all([k == centroid.mean for k, centroid in td.C.items()])
 
+    def test_empty_tdigest_compress(self, empty_tdigest):
+        td = empty_tdigest
+        td.compress()
+
 
 class TestStatisticalTests():
 


### PR DESCRIPTION
`pyudorandom` goes into a 100% cpu loop when passed an empty list, which happens when you compress an empty TDigest. Here I test that the TDigest is not empty before calling pyudorandom.