### PR TITLE
Upgrade pyudorandom to 1.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 bintrees
-pyudorandom
+pyudorandom>=1.0.0


### PR DESCRIPTION
I've pushed 1.0.0 of Pyudorandom to PyPi.

The `if` in https://github.com/CamDavidsonPilon/tdigest/pull/22 could be reverted now, or you can let it be.

