### PR TITLE
Revert "Do not compress empty tdigests"

### DIFF
--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -138,9 +138,8 @@ class TDigest(object):
     def compress(self):
         T = TDigest(self.delta, self.K)
         C = list(self.C.values())
-        if len(C) > 0:
-            for c_i in pyudorandom.items(C):
-                T.update(c_i.mean, c_i.count)
+        for c_i in pyudorandom.items(C):
+            T.update(c_i.mean, c_i.count)
         self.C = T.C
 
     def percentile(self, p):

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -130,10 +130,6 @@ class TestTDigest():
         td._add_centroid(Centroid(-1.1, 10))
         assert all([k == centroid.mean for k, centroid in td.C.items()])
 
-    def test_empty_tdigest_compress(self, empty_tdigest):
-        td = empty_tdigest
-        td.compress()
-
 
 class TestStatisticalTests():
 


### PR DESCRIPTION
Reverts CamDavidsonPilon/tdigest#22 since it's fixed in the upstream library

cc @zblz @mewwts 