### PR TITLE
Added serialize and deserialize methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ sum_digest.percentile(30)  # about 0.3
  - `percentile(p)`: return the `p`th percentile. Example: `p=50` is the median.
  - `cdf(x)`: return the CDF the value `x` is at. 
  - `trimmed_mean(p1, p2)`: return the mean of data set without the values below and above the `p1` and `p2` percentile respectively. 
+ - `serialize()`: return a Python dictionary of the TDigest and internal Centroid values.
+ - `deserialize()`: update from serialized dictionary values into the TDigest object.
 
  
 

--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -246,7 +246,27 @@ class TDigest(object):
             delta = (self.C.succ_item(key)[1].mean - self.C.prev_item(key)[1].mean) / 2.
         return (diff / k_i - 0.5) * delta
 
+    def serialize(self):
+        """
+        Returns a Python dictionary of the TDigest and internal Centroid values.
 
+        """
+        centroids = []
+        for key in self.C.keys():
+            tree_values = self.C.get_value(key)
+            centroids.append({'m':tree_values.mean, 'c':tree_values.count})
+        return {'n':self.n, 'delta':self.delta, 'K':self.K, 'centroids':centroids}
+    
+    def deserialize(self, dict_values):
+        """
+        Updates from serialized dictionary values into the TDigest object.
+
+        """
+        self.n = dict_values['n']
+        self.delta = dict_values['delta']
+        self.K = dict_values['K']
+        [self.update(value['m'], value['c']) for value in dict_values['centroids']]
+        return self
 
 if __name__ == '__main__':
     from numpy import random


### PR DESCRIPTION
This helps deal with the needs of issues #21 and #33. You should now be able to serialize your TDigest objects into a Python dict where you can send or store it with traditional means, like convert it to JSON.