### PR TITLE
Fix weights and add an edge case

### DIFF
--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -184,7 +184,7 @@ class TDigest(object):
                     z2 = t + k - p
                     return (c_i.mean * z1 + c_i_plus_one.mean * z2) / (z1 + z2)
                 if p == t + k:
-                    return c_i_plus_one
+                    return c_i_plus_one.mean
             c_i = c_i_plus_one
             t += k
 

--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -183,7 +183,7 @@ class TDigest(object):
                     z1 = p - t
                     z2 = t + k - p
                     return (c_i.mean * z1 + c_i_plus_one.mean * z2) / (z1 + z2)
-                if p == t + K:
+                if p == t + k:
                     return c_i_plus_one
             c_i = c_i_plus_one
             t += k

--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -182,7 +182,9 @@ class TDigest(object):
                 if p < t + k:
                     z1 = p - t
                     z2 = t + k - p
-                    return (c_i.mean * z2 + c_i_plus_one.mean * z1) / (z1 + z2)
+                    return (c_i.mean * z1 + c_i_plus_one.mean * z2) / (z1 + z2)
+                if p == t + K:
+                    return c_i_plus_one
             c_i = c_i_plus_one
             t += k
 

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -216,6 +216,11 @@ class TestStatisticalTests():
         t.batch_update(x)
         assert t.percentile(50) == 2
         assert sum([c.count for c in t.C.values()]) == len(x)
+        
+        t = TDigest()
+        t.batch_update([1, 1, 2, 2, 3, 4, 4, 4, 5, 5])
+        assert t.percentile(30) == 2
+        assert t.percentile(40) == 3.5        
 
     @pytest.mark.parametrize("percentile_range", [[0, 7], [27, 47], [39, 66], [81, 99], [77, 100], [0, 100]])
     @pytest.mark.parametrize("data_size", [100, 1000, 5000])


### PR DESCRIPTION
In the percentile function the  weighted arithmetic mean was with wrong weights order.
Also, when the requested percentile is in the middle of the bucket the function would bring the score between the current bucket and the next one.