### PR TITLE
fix weight in interpolation

### DIFF
--- a/tdigest/tdigest.py
+++ b/tdigest/tdigest.py
@@ -179,12 +179,10 @@ class TDigest(object):
 
             else:
                 k = (c_i_plus_one.count + c_i.count) / 2.
-                if p < t + k:
+                if p <= t + k:
                     z1 = p - t
                     z2 = t + k - p
-                    return (c_i.mean * z1 + c_i_plus_one.mean * z2) / (z1 + z2)
-                if p == t + k:
-                    return c_i_plus_one.mean
+                    return (c_i.mean * z2 + c_i_plus_one.mean * z1) / k
             c_i = c_i_plus_one
             t += k
 

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -151,7 +151,14 @@ class TestTDigest():
         t.batch_update(data)
         assert t.percentile(25) == 132.0
 
-    def test_adding_centroid_with_exisiting_key_does_not_break_synchronicity(self, empty_tdigest, example_centroids):
+    def test_percentile_weighted_interpolation(self, empty_tdigest):
+        data = [1, 10, 10, 10, 10, 100, 100, 100, 100, 1000]
+        t = TDigest()
+        t.batch_update(data)
+        print(t.centroids_to_list())
+        assert t.percentile(40) == 32.5
+
+    def test_adding_centroid_with_existing_key_does_not_break_synchronicity(self, empty_tdigest, example_centroids):
         td = empty_tdigest
         td.C = example_centroids
         assert -1.1 in td.C
@@ -220,7 +227,7 @@ class TestStatisticalTests():
         t = TDigest()
         t.batch_update([1, 1, 2, 2, 3, 4, 4, 4, 5, 5])
         assert t.percentile(30) == 2
-        assert t.percentile(40)*3 == 7
+        assert t.percentile(40)*3 == 8
 
     @pytest.mark.parametrize("percentile_range", [[0, 7], [27, 47], [39, 66], [81, 99], [77, 100], [0, 100]])
     @pytest.mark.parametrize("data_size", [100, 1000, 5000])

--- a/tests/test_tdigest.py
+++ b/tests/test_tdigest.py
@@ -142,7 +142,6 @@ class TestTDigest():
         # Test https://github.com/CamDavidsonPilon/tdigest/issues/16
         t = TDigest()
         t.batch_update([62.0, 202.0, 1415.0, 1433.0])
-        print(t.percentile(26))
         assert t.percentile(26) > 0
 
     def test_percentile_at_border_returns_an_intermediate_value(self, empty_tdigest):
@@ -155,7 +154,6 @@ class TestTDigest():
         data = [1, 10, 10, 10, 10, 100, 100, 100, 100, 1000]
         t = TDigest()
         t.batch_update(data)
-        print(t.centroids_to_list())
         assert t.percentile(40) == 32.5
 
     def test_adding_centroid_with_existing_key_does_not_break_synchronicity(self, empty_tdigest, example_centroids):


### PR DESCRIPTION
This is essentially: https://github.com/CamDavidsonPilon/tdigest/pull/52 with extra simplifications.

Intuitively if `p` is close to `t` (the mid point of the previous cluster), the weight for `c_i.mean` should be higher. Whereas right now `z1 = p - t` is smaller the closer `p` is to `t`.

Note that when we do this change, the `p == t + k` is handled too:

    z1 = p - t = t + k - t = k
    z2 = t + k - p = t + k - t - k = 0

Also noting that `k = z1 + z2`: 

    c_i.mean * z1 + c_i_plus_one.mean * z2) / (z1 + z2) = c_i.mean * k / k = c+i.mean

I added a test case to show case this:
   
     [1, 10, 10, 10, 10, 100, 100, 100, 100, 1000]

it currently returns `132.0` for `p=40`.
 
